### PR TITLE
Update GitHub Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The internal gh pages workflow fails to run as the older 20.24 version of ubuntu is no longer supported. By changing to latest, it will continue to work